### PR TITLE
Sprotty upgrade and diagram editing

### DIFF
--- a/css/dark/diagram.css
+++ b/css/dark/diagram.css
@@ -10,4 +10,5 @@
 @import "module.css";
 @import "edges.css";
 @import "popup.css";
+@import "text.css"
 

--- a/css/dark/edges.css
+++ b/css/dark/edges.css
@@ -15,8 +15,9 @@
     fill: #729A9A;
 }
 
-.sprotty-edge.dashed {
-    stroke-dasharray: 5 5;
+.sprotty-edge.specializes {
+    /* stroke-dasharray: 5 5; */
+    stroke: rgb(192, 190, 64);
 }
 
 

--- a/css/dark/edges.css
+++ b/css/dark/edges.css
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-.sprotty-edge {
+ .sprotty-edge {
     fill: none;
     stroke: #729A9A;
     stroke-width: 2px;
@@ -17,10 +17,13 @@
 
 .sprotty-edge.specializes {
     /* stroke-dasharray: 5 5; */
+    stroke: #729A9A;
+}
+
+.sprotty-edge.relationship {
     stroke: rgb(192, 190, 64);
 }
 
-
-
-
-
+.sprotty-edge.restriction {
+    stroke: rgb(192, 115, 64);
+}

--- a/css/dark/text.css
+++ b/css/dark/text.css
@@ -13,3 +13,8 @@ text.relationship {
     fill: rgb(192, 190, 64);
     stroke: rgb(192, 190, 64);
 }
+
+text.editable {
+    fill: rgb(192, 190, 64);
+    stroke: rgb(192, 190, 64);
+}

--- a/css/dark/text.css
+++ b/css/dark/text.css
@@ -1,0 +1,5 @@
+
+text.subtext {
+    fill: #729A9A;
+    stroke: #729A9A;
+}

--- a/css/dark/text.css
+++ b/css/dark/text.css
@@ -3,3 +3,13 @@ text.subtext {
     fill: #729A9A;
     stroke: #729A9A;
 }
+
+text.restriction {
+    fill: rgb(192, 115, 64);
+    stroke: rgb(192, 115, 64);
+}
+
+text.relationship {
+    fill: rgb(192, 190, 64);
+    stroke: rgb(192, 190, 64);
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "diagram"
   ],
   "dependencies": {
-    "sprotty": "0.5.0-next.90d9d8c2"
-  },
+    "sprotty": "0.6.0"
+},
   "scripts": {
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf lib",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "diagram"
   ],
   "dependencies": {
-    "sprotty": "0.5.0-next.90d9d8c2"
+    "sprotty": "next"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oml-sprotty",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "sprotty diagrams for the Oml DSL",
   "author": "typefox.io",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "diagram"
   ],
   "dependencies": {
-    "sprotty": "0.6.0"
-},
+    "sprotty": "0.5.0-next.90d9d8c2"
+  },
   "scripts": {
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf lib",

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -17,8 +17,9 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
 // import { popupModelFactory } from "./popup";
 import {CaseNodeView, ChoiceNodeView, ClassNodeView, CompositionEdgeView, DashedArrowEdgeView,
     DashedEdgeView, HeaderCompartmentView, ImportEdgeView, ModuleNodeView, NoteView, TagView,
-    UsesNodeView, CardinalLabelView, RestrictsArrowEdgeView, RelationshipLabelView, RestrictsLabelView, RelationshipArrowEdgeView } from "./views";
-import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge, OmlDiagram } from "./oml-models";
+    UsesNodeView, CardinalLabelView, RestrictsArrowEdgeView, RelationshipLabelView,
+    RestrictsLabelView, RelationshipArrowEdgeView } from "./views";
+import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge, OmlDiagram, OmlEditableLabel } from "./oml-models";
 import { OmlModelFactory } from "./model-factory";
 
 const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -39,6 +40,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'label:subtext', SLabel, CardinalLabelView)
     configureModelElement(context, 'label:restricts', SLabel, RestrictsLabelView)
     configureModelElement(context, 'label:relationship', SLabel, RelationshipLabelView)
+    configureModelElement(context, 'label:editable', OmlEditableLabel, SLabelView)
     configureModelElement(context, 'ylabel:text', OmlLabel, SLabelView)
     configureModelElement(context, 'label:classHeader', SLabel, SLabelView)
     configureModelElement(context, 'tag', Tag, TagView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -15,8 +15,8 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
     openModule, overrideViewerOptions, routingModule, selectModule, updateModule, undoRedoModule,
     viewportModule, SButton, SModelRoot } from 'sprotty';
 // import { popupModelFactory } from "./popup";
-import {CaseNodeView, ChoiceNodeView, ClassNodeView, CompositionEdgeView, DashedArrowEdgeView,
-    DashedEdgeView, HeaderCompartmentView, ImportEdgeView, ModuleNodeView, NoteView, TagView,
+import {CaseNodeView, ChoiceNodeView, ClassNodeView, CompositionEdgeView, SpecializationArrowEdgeView,
+    SpecializationEdgeView, HeaderCompartmentView, ImportEdgeView, ModuleNodeView, NoteView, TagView,
     UsesNodeView, CardinalLabelView, RestrictsArrowEdgeView, RelationshipLabelView,
     RestrictsLabelView, RelationshipArrowEdgeView } from "./views";
 import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge, OmlDiagram, OmlEditableLabel } from "./oml-models";
@@ -49,9 +49,9 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'comp:classHeader', SCompartment, HeaderCompartmentView)
     configureModelElement(context, 'edge:straight', OmlEdge, PolylineEdgeView)
     configureModelElement(context, 'edge:composition', OmlEdge, CompositionEdgeView)
-    configureModelElement(context, 'edge:dashed', OmlEdge, DashedEdgeView)
+    configureModelElement(context, 'edge:dashed', OmlEdge, SpecializationEdgeView)
     configureModelElement(context, 'edge:import', OmlEdge, ImportEdgeView)
-    configureModelElement(context, 'edge:uses', OmlEdge, DashedArrowEdgeView)
+    configureModelElement(context, 'edge:uses', OmlEdge, SpecializationArrowEdgeView)
     configureModelElement(context, 'edge:augments', OmlEdge, RelationshipArrowEdgeView)
     configureModelElement(context, 'edge:restricts', OmlEdge, RestrictsArrowEdgeView)
     configureModelElement(context, 'edge:relationship', OmlEdge, RelationshipLabelView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -13,7 +13,7 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
         exportModule, fadeModule, hoverModule, modelSourceModule, moveModule,
         openModule, overrideViewerOptions, selectModule, undoRedoModule,
         viewportModule, SButton, PolylineEdgeView } from 'sprotty/lib';
-import { popupModelFactory } from "./popup";
+// import { popupModelFactory } from "./popup";
 import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, /*StandardEdgeView,*/
     CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
     ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView, CardinalLabelView } from "./views";
@@ -24,7 +24,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope()
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn)
     rebind(TYPES.IModelFactory).to(OmlModelFactory).inSingletonScope()
-    bind(TYPES.PopupModelFactory).toConstantValue(popupModelFactory)
+    // bind(TYPES.PopupModelFactory).toConstantValue(popupModelFactory)
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, 'graph', SGraph, SGraphView);
     configureModelElement(context, 'node:class', OmlNode, ClassNodeView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -6,13 +6,14 @@
  */
 import { Container, ContainerModule } from "inversify";
 import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
-        HtmlRootView, LogLevel, PreRenderedElement,
-        PreRenderedView, SCompartment, SCompartmentView, SGraph,
-        SGraphView, SLabel, SLabelView, TYPES, boundsModule,
-        buttonModule, configureModelElement, defaultModule, expandModule,
-        exportModule, fadeModule, hoverModule, modelSourceModule, moveModule,
-        openModule, overrideViewerOptions, selectModule, undoRedoModule,
-        viewportModule, SButton, PolylineEdgeView } from 'sprotty/lib';
+    HtmlRootView, LogLevel, PolylineEdgeView, PreRenderedElement,
+    PreRenderedView, SCompartment, SCompartmentView, SGraph,
+    SGraphView, SLabel, SLabelView, TYPES, boundsModule,
+    buttonModule, configureModelElement, decorationModule, defaultModule,
+    edgeEditModule, edgeLayoutModule, expandModule,
+    exportModule, fadeModule, hoverModule, labelEditModule, modelSourceModule, moveModule,
+    openModule, overrideViewerOptions, routingModule, selectModule, updateModule, undoRedoModule,
+    viewportModule, SButton } from 'sprotty';
 // import { popupModelFactory } from "./popup";
 import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, /*StandardEdgeView,*/
     CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
@@ -55,9 +56,12 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
 
 export default function createContainer(widgetId: string): Container {
     const container = new Container()
-    container.load(defaultModule, selectModule, moveModule, boundsModule, undoRedoModule, viewportModule,
+    container.load(
+        defaultModule, selectModule, moveModule, boundsModule, undoRedoModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule,
-        omlDiagramModule)
+        decorationModule, edgeEditModule, edgeLayoutModule, labelEditModule, updateModule, routingModule,
+        omlDiagramModule
+    );
     //        container.bind(TYPES.ModelSource).to(TheiaDiagramServer).inSingletonScope()
     overrideViewerOptions(container, {
         needsClientLayout: true,

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -7,18 +7,18 @@
 import { Container, ContainerModule } from "inversify";
 import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
     HtmlRootView, LogLevel, PolylineEdgeView, PreRenderedElement,
-    PreRenderedView, SCompartment, SCompartmentView, SGraph,
+    PreRenderedView, SCompartment, SCompartmentView,
     SGraphView, SLabel, SLabelView, TYPES, boundsModule,
     buttonModule, configureModelElement, decorationModule, defaultModule,
     edgeEditModule, edgeLayoutModule, expandModule,
     exportModule, fadeModule, hoverModule, labelEditModule, modelSourceModule, moveModule,
     openModule, overrideViewerOptions, routingModule, selectModule, updateModule, undoRedoModule,
-    viewportModule, SButton } from 'sprotty';
+    viewportModule, SButton, SModelRoot } from 'sprotty';
 // import { popupModelFactory } from "./popup";
-import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, /*StandardEdgeView,*/
-    CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
-    ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView, CardinalLabelView } from "./views";
-import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge } from "./oml-models";
+import {CaseNodeView, ChoiceNodeView, ClassNodeView, CompositionEdgeView, DashedArrowEdgeView,
+    DashedEdgeView, HeaderCompartmentView, ImportEdgeView, ModuleNodeView, NoteView, TagView,
+    UsesNodeView, CardinalLabelView, RestrictsArrowEdgeView, RelationshipLabelView, RestrictsLabelView, RelationshipArrowEdgeView } from "./views";
+import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge, OmlDiagram } from "./oml-models";
 import { OmlModelFactory } from "./model-factory";
 
 const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -27,7 +27,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     rebind(TYPES.IModelFactory).to(OmlModelFactory).inSingletonScope()
     // bind(TYPES.PopupModelFactory).toConstantValue(popupModelFactory)
     const context = { bind, unbind, isBound, rebind };
-    configureModelElement(context, 'graph', SGraph, SGraphView);
+    configureModelElement(context, 'graph', OmlDiagram, SGraphView);
     configureModelElement(context, 'node:class', OmlNode, ClassNodeView)
     configureModelElement(context, 'node:module', ModuleNode, ModuleNodeView)
     configureModelElement(context, 'node:choice', OmlNode, ChoiceNodeView)
@@ -37,6 +37,8 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'label:heading', SLabel, SLabelView)
     configureModelElement(context, 'label:text', SLabel, SLabelView)
     configureModelElement(context, 'label:subtext', SLabel, CardinalLabelView)
+    configureModelElement(context, 'label:restricts', SLabel, RestrictsLabelView)
+    configureModelElement(context, 'label:relationship', SLabel, RelationshipLabelView)
     configureModelElement(context, 'ylabel:text', OmlLabel, SLabelView)
     configureModelElement(context, 'label:classHeader', SLabel, SLabelView)
     configureModelElement(context, 'tag', Tag, TagView)
@@ -48,7 +50,10 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'edge:dashed', OmlEdge, DashedEdgeView)
     configureModelElement(context, 'edge:import', OmlEdge, ImportEdgeView)
     configureModelElement(context, 'edge:uses', OmlEdge, DashedArrowEdgeView)
-    configureModelElement(context, 'edge:augments', OmlEdge, ArrowEdgeView)
+    configureModelElement(context, 'edge:augments', OmlEdge, RelationshipArrowEdgeView)
+    configureModelElement(context, 'edge:restricts', OmlEdge, RestrictsArrowEdgeView)
+    configureModelElement(context, 'edge:relationship', OmlEdge, RelationshipLabelView)
+    configureModelElement(context, 'palette', SModelRoot, HtmlRootView)
     configureModelElement(context, 'html', HtmlRoot, HtmlRootView)
     configureModelElement(context, 'pre-rendered', PreRenderedElement, PreRenderedView)
     configureModelElement(context, ExpandButtonHandler.TYPE, SButton, ExpandButtonView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -71,7 +71,8 @@ export default function createContainer(widgetId: string): Container {
     overrideViewerOptions(container, {
         needsClientLayout: true,
         needsServerLayout: true,
-        baseDiv: widgetId
+        baseDiv: widgetId,
+        hiddenDiv: widgetId + '_hidden'
     })
     return container
 }

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -6,7 +6,7 @@
  */
 import { Container, ContainerModule } from "inversify";
 import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
-        HtmlRootView, LogLevel, PolylineEdgeView, PreRenderedElement,
+        HtmlRootView, LogLevel, PreRenderedElement,
         PreRenderedView, SCompartment, SCompartmentView, SGraph,
         SGraphView, SLabel, SLabelView, TYPES, boundsModule,
         buttonModule, configureModelElement, defaultModule, expandModule,
@@ -14,7 +14,7 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
         openModule, overrideViewerOptions, selectModule, undoRedoModule,
         viewportModule, SButton } from 'sprotty/lib';
 import { popupModelFactory } from "./popup";
-import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView,
+import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, StandardEdgeView,
     CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
     ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView } from "./views";
 import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge } from "./oml-models";
@@ -41,7 +41,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'label:tag', SLabel, SLabelView)
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView)
     configureModelElement(context, 'comp:classHeader', SCompartment, HeaderCompartmentView)
-    configureModelElement(context, 'edge:straight', OmlEdge, PolylineEdgeView)
+    configureModelElement(context, 'edge:straight', OmlEdge, StandardEdgeView)
     configureModelElement(context, 'edge:composition', OmlEdge, CompositionEdgeView)
     configureModelElement(context, 'edge:dashed', OmlEdge, DashedEdgeView)
     configureModelElement(context, 'edge:import', OmlEdge, ImportEdgeView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -12,9 +12,9 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
         buttonModule, configureModelElement, defaultModule, expandModule,
         exportModule, fadeModule, hoverModule, modelSourceModule, moveModule,
         openModule, overrideViewerOptions, selectModule, undoRedoModule,
-        viewportModule, SButton } from 'sprotty/lib';
+        viewportModule, SButton, PolylineEdgeView } from 'sprotty/lib';
 import { popupModelFactory } from "./popup";
-import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, StandardEdgeView,
+import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, /*StandardEdgeView,*/
     CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
     ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView } from "./views";
 import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge } from "./oml-models";
@@ -41,7 +41,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'label:tag', SLabel, SLabelView)
     configureModelElement(context, 'comp:comp', SCompartment, SCompartmentView)
     configureModelElement(context, 'comp:classHeader', SCompartment, HeaderCompartmentView)
-    configureModelElement(context, 'edge:straight', OmlEdge, StandardEdgeView)
+    configureModelElement(context, 'edge:straight', OmlEdge, PolylineEdgeView)
     configureModelElement(context, 'edge:composition', OmlEdge, CompositionEdgeView)
     configureModelElement(context, 'edge:dashed', OmlEdge, DashedEdgeView)
     configureModelElement(context, 'edge:import', OmlEdge, ImportEdgeView)

--- a/src/di.config.ts
+++ b/src/di.config.ts
@@ -16,7 +16,7 @@ import { ConsoleLogger, ExpandButtonHandler, ExpandButtonView, HtmlRoot,
 import { popupModelFactory } from "./popup";
 import { ArrowEdgeView, CaseNodeView, ChoiceNodeView, ClassNodeView, /*StandardEdgeView,*/
     CompositionEdgeView, DashedArrowEdgeView, DashedEdgeView, HeaderCompartmentView,
-    ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView } from "./views";
+    ImportEdgeView, ModuleNodeView, NoteView, TagView, UsesNodeView, CardinalLabelView } from "./views";
 import { ModuleNode, Tag, OmlLabel, OmlNode, OmlEdge } from "./oml-models";
 import { OmlModelFactory } from "./model-factory";
 
@@ -35,6 +35,7 @@ const omlDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => 
     configureModelElement(context, 'node:note', OmlNode, NoteView)
     configureModelElement(context, 'label:heading', SLabel, SLabelView)
     configureModelElement(context, 'label:text', SLabel, SLabelView)
+    configureModelElement(context, 'label:subtext', SLabel, CardinalLabelView)
     configureModelElement(context, 'ylabel:text', OmlLabel, SLabelView)
     configureModelElement(context, 'label:classHeader', SLabel, SLabelView)
     configureModelElement(context, 'tag', Tag, TagView)

--- a/src/html-views.tsx
+++ b/src/html-views.tsx
@@ -8,6 +8,6 @@ import { injectable } from "inversify";
 @injectable()
 export class PaletteButtonView implements IView {
     render(button: SButton, context: RenderingContext): VNode {
-        return <div>{`INFO: ${button.id}`}</div>;
+        return <div>{button.id}</div>;
     }
 }

--- a/src/html-views.tsx
+++ b/src/html-views.tsx
@@ -1,0 +1,13 @@
+/** @jsx html */
+
+import { html } from "snabbdom-jsx";
+import { RenderingContext, IView, SButton } from "sprotty/lib";
+import { VNode } from "snabbdom/vnode";
+import { injectable } from "inversify";
+
+@injectable()
+export class PaletteButtonView implements IView {
+    render(button: SButton, context: RenderingContext): VNode {
+        return <div>{`INFO: ${button.id}`}</div>;
+    }
+}

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -1,5 +1,8 @@
-import { SGraphFactory, SModelElementSchema, SParentElement, SChildElement, getSubType, SEdge } from "sprotty";
+import { SGraphFactory, SModelElementSchema, SParentElement, SChildElement,
+    getSubType, SEdge, SLabel, EdgePlacement } from "sprotty";
+import { injectable } from "inversify";
 
+@injectable()
 export class OmlModelFactory extends SGraphFactory {
 
     readonly SQRT_5 = Math.sqrt(5)
@@ -23,5 +26,19 @@ export class OmlModelFactory extends SGraphFactory {
             }
         }
         return element
+    }
+
+    protected initializeChild(child: SChildElement, schema: SModelElementSchema, parent?: SParentElement): SChildElement {
+        super.initializeChild(child, schema, parent);
+        if (child instanceof SEdge) {
+            // child.routerKind = ManhattanEdgeRouter.KIND;
+            child.targetAnchorCorrection = Math.sqrt(5);
+        } else if (child instanceof SLabel) {
+            child.edgePlacement = <EdgePlacement> {
+                rotate: false,
+                position: 0.5
+            };
+        }
+        return child;
     }
 }

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -1,4 +1,4 @@
-import { SGraphFactory, SModelElementSchema, SParentElement, SChildElement, getSubType, SEdge } from "sprotty/lib";
+import { SGraphFactory, SModelElementSchema, SParentElement, SChildElement, getSubType, SEdge } from "sprotty";
 
 export class OmlModelFactory extends SGraphFactory {
 

--- a/src/oml-models.ts
+++ b/src/oml-models.ts
@@ -8,7 +8,7 @@
 import {
     boundsFeature, fadeFeature, hoverFeedbackFeature, popupFeature, SCompartment, selectFeature, layoutContainerFeature,
     layoutableChildFeature, SLabel, SShapeElement, expandFeature, Expandable, openFeature, RectangularNode, SEdge
-} from "sprotty/lib"
+} from "sprotty"
 
 export class OmlEdge extends SEdge {
     trace: String | undefined

--- a/src/oml-models.ts
+++ b/src/oml-models.ts
@@ -7,7 +7,7 @@
 
 import {
     boundsFeature, fadeFeature, hoverFeedbackFeature, popupFeature, SCompartment, selectFeature, layoutContainerFeature,
-    layoutableChildFeature, SLabel, SShapeElement, expandFeature, Expandable, openFeature, RectangularNode, SEdge, SGraph
+    layoutableChildFeature, SLabel, SShapeElement, expandFeature, Expandable, openFeature, RectangularNode, SEdge, SGraph, EditableLabel, editLabelFeature
 } from "sprotty"
 
 export class OmlDiagram extends SGraph {
@@ -51,8 +51,14 @@ export class OmlHeaderNode extends SCompartment {
 export class OmlLabel extends SLabel {
     trace: string | undefined
 
-    hasFeature(feature: symbol) {
+    hasFeature(feature: symbol): boolean {
         return super.hasFeature(feature) || feature === selectFeature || (feature === openFeature && this.trace !== undefined)
+    }
+}
+
+export class OmlEditableLabel extends OmlLabel implements EditableLabel {
+    hasFeature(feature: symbol): boolean {
+        return feature === editLabelFeature || super.hasFeature(feature);
     }
 }
 
@@ -67,6 +73,7 @@ export class Tag extends SShapeElement {
     }
 
     hasFeature(feature: symbol): boolean {
-        return feature === boundsFeature || feature === layoutContainerFeature || feature === layoutableChildFeature || feature === fadeFeature
+        return feature === boundsFeature || feature === layoutContainerFeature
+            || feature === layoutableChildFeature || feature === fadeFeature
     }
 }

--- a/src/oml-models.ts
+++ b/src/oml-models.ts
@@ -7,8 +7,14 @@
 
 import {
     boundsFeature, fadeFeature, hoverFeedbackFeature, popupFeature, SCompartment, selectFeature, layoutContainerFeature,
-    layoutableChildFeature, SLabel, SShapeElement, expandFeature, Expandable, openFeature, RectangularNode, SEdge
+    layoutableChildFeature, SLabel, SShapeElement, expandFeature, Expandable, openFeature, RectangularNode, SEdge, SGraph
 } from "sprotty"
+
+export class OmlDiagram extends SGraph {
+    hasFeature(feature: symbol): boolean {
+        return feature === hoverFeedbackFeature || feature === popupFeature || super.hasFeature(feature)
+    }
+}
 
 export class OmlEdge extends SEdge {
     trace: String | undefined

--- a/src/oml-models.ts
+++ b/src/oml-models.ts
@@ -50,6 +50,10 @@ export class OmlLabel extends SLabel {
     }
 }
 
+// export class OmlSubtext extends SLabel {
+//     edgePlacement: EdgePlacement = 0
+// }
+
 export class Tag extends SShapeElement {
     size = {
         width: 24,

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { SModelElementSchema, SModelRootSchema, RequestPopupModelAction, PreRenderedElementSchema } from "sprotty/lib"
+import { SModelElementSchema, SModelRootSchema, RequestPopupModelAction, PreRenderedElementSchema } from "sprotty"
 
 // TODO delete?
 export function popupModelFactory(request: RequestPopupModelAction, element?: SModelElementSchema): SModelRootSchema | undefined {

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -14,7 +14,8 @@ import {
     PolylineEdgeView,
     Point,
     toDegrees, IView, setAttr, SLabel,
-    getSubType
+    getSubType,
+    SLabelView
 } from "sprotty/lib"
 import { VNode } from "snabbdom/vnode"
 import { OmlNode, ModuleNode, OmlEdge, Tag } from "./oml-models"
@@ -220,6 +221,16 @@ export class DashedArrowEdgeView extends DashedEdgeView {
 export class InvFunctionalView implements IView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         const vnode = <text class-sprotty-label={true}>{label.text}</text>;
+        const subType = getSubType(label);
+        if (subType)
+            setAttr(vnode, 'class', subType);
+        return vnode;
+    }
+}
+
+export class CardinalLabelView extends SLabelView {
+    render(label: Readonly<SLabel>, context: RenderingContext): VNode {
+        const vnode = <text class-sprotty-label={true} class-subtext={true}>{label.text}</text>;
         const subType = getSubType(label);
         if (subType)
             setAttr(vnode, 'class', subType);

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -121,7 +121,7 @@ export class CompositionEdgeView extends PolylineEdgeView {
         const p1 = segments[0]
         const p2 = segments[1]
         const r = 6
-        const rhombStr = "M 0,0 l" + r + "," + (r / 2) + " l" + r + ",-" + (r / 2) + " l-" + r + ",-" + (r / 2) + " l-" + r + "," + (r / 2) + " Z"
+        const rhombStr = `M 0,0 l${r},${r / 2} l${r},-${r / 2} l-${r},-${r / 2} l-${r},${r / 2} Z`
         return [
             <path class-sprotty-edge={true} class-composition={true} d={rhombStr}
                   transform={`rotate(${angle(p1, p2)} ${p1.x} ${p1.y}) translate(${p1.x} ${p1.y})`}/>
@@ -135,15 +135,31 @@ export class CompositionEdgeView extends PolylineEdgeView {
     }
 }
 
+export class StandardEdgeView extends PolylineEdgeView {
+    protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
+        const firstPoint = segments[0]
+        let path = `M ${firstPoint.x},${firstPoint.y}`
+        for (let i = 1; i < segments.length - 1; i++) {
+            const p = segments[i]
+            path += ` L ${p.x},${p.y}`
+        }
+        const lastPoint = segments[segments.length - 1];
+        path += ` L ${lastPoint.x}, ${lastPoint.y > firstPoint.y ? lastPoint.y - 10 : lastPoint.y + 10}`
+        return <path class-sprotty-edge={true} d={path}/>
+    }
+}
+
 export class DashedEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
         let path = `M ${firstPoint.x},${firstPoint.y}`
-        for (let i = 1; i < segments.length; i++) {
+        for (let i = 1; i < segments.length - 1; i++) {
             const p = segments[i]
             path += ` L ${p.x},${p.y}`
         }
-        return <path class-sprotty-edge={true} class-dashed={true} d={path}/>
+        const lastPoint = segments[segments.length - 1];
+        path += ` L ${lastPoint.x}, ${lastPoint.y > firstPoint.y ? lastPoint.y - 10 : lastPoint.y + 10}`
+        return <path class-sprotty-edge={true} class-specializes={true} d={path}/>
     }
 }
 
@@ -169,7 +185,7 @@ export class ArrowEdgeView extends PolylineEdgeView {
         const p1 = segments[segments.length - 2]
         const p2 = segments[segments.length - 1]
         return [
-            <path class-sprotty-edge={true} d="M 10,-4 L 0,0 L 10,4"
+            <polygon class-sprotty-edge={true} points="10,-4 0,0 10,4"
                   transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
         ]
     }
@@ -186,7 +202,7 @@ export class DashedArrowEdgeView extends DashedEdgeView {
         const p1 = segments[segments.length - 2]
         const p2 = segments[segments.length - 1]
         return [
-            <path class-sprotty-edge={true} d="M 10,-4 L 0,0 L 10,4"
+            <polygon class-sprotty-edge={true} class-specializes={true} points="10,-4 0,0 10,4"
                   transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
         ]
     }

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -230,6 +230,7 @@ export class InvFunctionalView implements IView {
 
 export class CardinalLabelView extends SLabelView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
+        console.log("LABEL:", label);
         const vnode = <text class-sprotty-label={true} class-subtext={true}>{label.text}</text>;
         const subType = getSubType(label);
         if (subType)

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -179,7 +179,7 @@ export class RelationshipEdgeView extends PolylineEdgeView {
 }
 
 @injectable()
-export class DashedEdgeView extends PolylineEdgeView {
+export class SpecializationEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
         let path = `M ${firstPoint.x},${firstPoint.y}`
@@ -209,7 +209,7 @@ export class RestrictsEdgeView extends PolylineEdgeView {
 }
 
 @injectable()
-export class ImportEdgeView extends DashedEdgeView {
+export class ImportEdgeView extends SpecializationEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[0]
         const p2 = segments[1]
@@ -283,7 +283,7 @@ export class RestrictsArrowEdgeView extends RestrictsEdgeView {
 }
 
 @injectable()
-export class DashedArrowEdgeView extends DashedEdgeView {
+export class SpecializationArrowEdgeView extends SpecializationEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
         const p2 = segments[segments.length - 1]
@@ -296,7 +296,7 @@ export class DashedArrowEdgeView extends DashedEdgeView {
     static readonly TARGET_CORRECTION = Math.sqrt(1 * 1 + 2.5 * 2.5)
 
     protected getTargetAnchorCorrection(edge: OmlEdge): number {
-        return DashedArrowEdgeView.TARGET_CORRECTION
+        return SpecializationArrowEdgeView.TARGET_CORRECTION
     }
 }
 

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -163,6 +163,20 @@ export class StandardEdgeView extends PolylineEdgeView {
     }
 }
 
+export class RelationshipEdgeView extends PolylineEdgeView {
+    protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
+        const firstPoint = segments[0]
+        let path = `M ${firstPoint.x},${firstPoint.y}`
+        for (let i = 1; i < segments.length - 1; i++) {
+            const p = segments[i]
+            path += ` L ${p.x},${p.y}`
+        }
+        const lastPoint = segments[segments.length - 1];
+        path += ` L ${lastPoint.x}, ${lastPoint.y}`
+        return <path class-sprotty-edge={true} class-relationship={true} d={path}/>
+    }
+}
+
 @injectable()
 export class DashedEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
@@ -175,6 +189,20 @@ export class DashedEdgeView extends PolylineEdgeView {
         const lastPoint = segments[segments.length - 1];
         path += ` L ${lastPoint.x}, ${lastPoint.y > firstPoint.y ? lastPoint.y - 10 : lastPoint.y + 10}`
         return <path class-sprotty-edge={true} class-specializes={true} d={path}/>
+    }
+}
+
+export class RestrictsEdgeView extends PolylineEdgeView {
+    protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
+        const firstPoint = segments[0]
+        let path = `M ${firstPoint.x},${firstPoint.y}`
+        for (let i = 1; i < segments.length - 1; i++) {
+            const p = segments[i]
+            path += ` L ${p.x},${p.y}`
+        }
+        const lastPoint = segments[segments.length - 1];
+        path += ` L ${lastPoint.x}, ${lastPoint.y}`
+        return <path class-sprotty-edge={true} class-restriction={true} d={path}/>
     }
 }
 
@@ -204,6 +232,42 @@ export class ArrowEdgeView extends StandardEdgeView {
         return [
             <polygon class-sprotty-edge={true} points="10,-4 0,0 10,4"
                   transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
+        ]
+    }
+
+    static readonly TARGET_CORRECTION = Math.sqrt(1 * 1 + 2.5 * 2.5)
+
+    protected getTargetAnchorCorrection(edge: OmlEdge): number {
+        return ArrowEdgeView.TARGET_CORRECTION
+    }
+}
+
+export class RelationshipArrowEdgeView extends RelationshipEdgeView {
+    protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
+        const p1 = segments[segments.length - 2]
+        const p2 = segments[segments.length - 1]
+        return [
+            <path class-sprotty-edge={true} class-relationship={true} d="M 10,-4 L 0,0 L 10,4"
+                transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />
+        ]
+    }
+
+    static readonly TARGET_CORRECTION = Math.sqrt(1 * 1 + 2.5 * 2.5)
+
+    protected getTargetAnchorCorrection(edge: OmlEdge): number {
+        return ArrowEdgeView.TARGET_CORRECTION
+    }
+}
+
+export class RestrictsArrowEdgeView extends RestrictsEdgeView {
+    protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
+        const p1 = segments[segments.length - 2]
+        const p2 = segments[segments.length - 1]
+        return [
+            <path class-sprotty-edge={true} class-restriction={true} d="M 10,-4 L 0,0 L 10,4"
+                transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`} />
+            // <polygon class-sprotty-edge={true} class-restriction={true} points="10,-4 0,0 10,4"
+            //       transform={`rotate(${angle(p2, p1)} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
         ]
     }
 
@@ -248,6 +312,26 @@ export class CardinalLabelView extends SLabelView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         console.log("LABEL:", label);
         const vnode = <text class-sprotty-label={true} class-subtext={true}>{label.text}</text>;
+        const subType = getSubType(label);
+        if (subType)
+            setAttr(vnode, 'class', subType);
+        return vnode;
+    }
+}
+
+export class RestrictsLabelView extends SLabelView {
+    render(label: Readonly<SLabel>, context: RenderingContext): VNode {
+        const vnode = <text class-sprotty-label={true} class-restriction={true}>{label.text}</text>;
+        const subType = getSubType(label);
+        if (subType)
+            setAttr(vnode, 'class', subType);
+        return vnode;
+    }
+}
+
+export class RelationshipLabelView extends SLabelView {
+    render(label: Readonly<SLabel>, context: RenderingContext): VNode {
+        const vnode = <text class-sprotty-label={true} class-relationship={true}>{label.text}</text>;
         const subType = getSubType(label);
         if (subType)
             setAttr(vnode, 'class', subType);

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -7,7 +7,7 @@
 
 /** @jsx svg */
 import { svg } from 'snabbdom-jsx';
-
+import { injectable } from "inversify";
 import {
     RenderingContext,
     SCompartment,
@@ -16,10 +16,11 @@ import {
     toDegrees, IView, setAttr, SLabel,
     getSubType,
     SLabelView
-} from "sprotty/lib"
+} from "sprotty"
 import { VNode } from "snabbdom/vnode"
 import { OmlNode, ModuleNode, OmlEdge, Tag } from "./oml-models"
 
+@injectable()
 export class ClassNodeView implements IView {
     render(node: OmlNode, context: RenderingContext): VNode {
         const vnode = <g class-sprotty-node={true}>
@@ -33,6 +34,7 @@ export class ClassNodeView implements IView {
     }
 }
 
+@injectable()
 export class HeaderCompartmentView implements IView {
     render(model: SCompartment, context: RenderingContext): VNode {
         const translate = `translate(${model.bounds.x}, ${model.bounds.y})`
@@ -47,6 +49,7 @@ export class HeaderCompartmentView implements IView {
     }
 }
 
+@injectable()
 export class TagView implements IView {
     render(element: Tag, context: RenderingContext): VNode {
         const radius = 0.5 * element.size.width
@@ -57,6 +60,7 @@ export class TagView implements IView {
     }
 }
 
+@injectable()
 export class ModuleNodeView implements IView {
     render(node: ModuleNode, context: RenderingContext): VNode {
         return <g class-sprotty-node={true} class-module={true} class-mouseover={node.hoverFeedback}>
@@ -68,6 +72,7 @@ export class ModuleNodeView implements IView {
     }
 }
 
+@injectable()
 export class ChoiceNodeView implements IView {
     render(model: OmlNode, context: RenderingContext): VNode {
         const width = Math.max(0, model.size.width * 0.5)
@@ -81,6 +86,7 @@ export class ChoiceNodeView implements IView {
     }
 }
 
+@injectable()
 export class CaseNodeView implements IView {
     render(node: OmlNode, context: RenderingContext): VNode {
         const vnode = <g class-sprotty-node="{true}">
@@ -95,6 +101,7 @@ export class CaseNodeView implements IView {
     }
 }
 
+@injectable()
 export class UsesNodeView extends CaseNodeView {
     render(node: OmlNode, context: RenderingContext): VNode {
         const vnode = <g class-sprotty-node={true}>
@@ -109,6 +116,7 @@ export class UsesNodeView extends CaseNodeView {
     }
 }
 
+@injectable()
 export class NoteView implements IView {
     render(node: OmlNode, context: RenderingContext): VNode {
         return <g class-note={true} class-mouseover={node.hoverFeedback}>
@@ -118,6 +126,7 @@ export class NoteView implements IView {
     }
 }
 
+@injectable()
 export class CompositionEdgeView extends PolylineEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[0]
@@ -137,6 +146,7 @@ export class CompositionEdgeView extends PolylineEdgeView {
     }
 }
 
+@injectable()
 export class StandardEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
@@ -153,6 +163,7 @@ export class StandardEdgeView extends PolylineEdgeView {
     }
 }
 
+@injectable()
 export class DashedEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
@@ -167,6 +178,7 @@ export class DashedEdgeView extends PolylineEdgeView {
     }
 }
 
+@injectable()
 export class ImportEdgeView extends DashedEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[0]
@@ -184,6 +196,7 @@ export class ImportEdgeView extends DashedEdgeView {
     }
 }
 
+@injectable()
 export class ArrowEdgeView extends StandardEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
@@ -201,6 +214,7 @@ export class ArrowEdgeView extends StandardEdgeView {
     }
 }
 
+@injectable()
 export class DashedArrowEdgeView extends DashedEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
@@ -218,6 +232,7 @@ export class DashedArrowEdgeView extends DashedEdgeView {
     }
 }
 
+@injectable()
 export class InvFunctionalView implements IView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         const vnode = <text class-sprotty-label={true}>{label.text}</text>;
@@ -228,6 +243,7 @@ export class InvFunctionalView implements IView {
     }
 }
 
+@injectable()
 export class CardinalLabelView extends SLabelView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         console.log("LABEL:", label);

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -13,7 +13,8 @@ import {
     SCompartment,
     PolylineEdgeView,
     Point,
-    toDegrees, IView, setAttr
+    toDegrees, IView, setAttr, SLabel,
+    getSubType
 } from "sprotty/lib"
 import { VNode } from "snabbdom/vnode"
 import { OmlNode, ModuleNode, OmlEdge, Tag } from "./oml-models"
@@ -143,8 +144,10 @@ export class StandardEdgeView extends PolylineEdgeView {
             const p = segments[i]
             path += ` L ${p.x},${p.y}`
         }
+        const secondLastPoint = segments[segments.length - 2];
         const lastPoint = segments[segments.length - 1];
-        path += ` L ${lastPoint.x}, ${lastPoint.y > firstPoint.y ? lastPoint.y - 10 : lastPoint.y + 10}`
+        const isDownArrow = lastPoint.y > secondLastPoint.y
+        path += ` L ${lastPoint.x}, ${isDownArrow ? lastPoint.y - 10 : lastPoint.y + 10}`
         return <path class-sprotty-edge={true} d={path}/>
     }
 }
@@ -180,7 +183,7 @@ export class ImportEdgeView extends DashedEdgeView {
     }
 }
 
-export class ArrowEdgeView extends PolylineEdgeView {
+export class ArrowEdgeView extends StandardEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
         const p2 = segments[segments.length - 1]
@@ -211,6 +214,16 @@ export class DashedArrowEdgeView extends DashedEdgeView {
 
     protected getTargetAnchorCorrection(edge: OmlEdge): number {
         return DashedArrowEdgeView.TARGET_CORRECTION
+    }
+}
+
+export class InvFunctionalView implements IView {
+    render(label: Readonly<SLabel>, context: RenderingContext): VNode {
+        const vnode = <text class-sprotty-label={true}>{label.text}</text>;
+        const subType = getSubType(label);
+        if (subType)
+            setAttr(vnode, 'class', subType);
+        return vnode;
     }
 }
 

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -163,6 +163,7 @@ export class StandardEdgeView extends PolylineEdgeView {
     }
 }
 
+@injectable()
 export class RelationshipEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
@@ -192,6 +193,7 @@ export class DashedEdgeView extends PolylineEdgeView {
     }
 }
 
+@injectable()
 export class RestrictsEdgeView extends PolylineEdgeView {
     protected renderLine(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode {
         const firstPoint = segments[0]
@@ -242,6 +244,7 @@ export class ArrowEdgeView extends StandardEdgeView {
     }
 }
 
+@injectable()
 export class RelationshipArrowEdgeView extends RelationshipEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
@@ -259,6 +262,7 @@ export class RelationshipArrowEdgeView extends RelationshipEdgeView {
     }
 }
 
+@injectable()
 export class RestrictsArrowEdgeView extends RestrictsEdgeView {
     protected renderAdditionals(edge: OmlEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2]
@@ -319,6 +323,7 @@ export class CardinalLabelView extends SLabelView {
     }
 }
 
+@injectable()
 export class RestrictsLabelView extends SLabelView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         const vnode = <text class-sprotty-label={true} class-restriction={true}>{label.text}</text>;
@@ -329,6 +334,7 @@ export class RestrictsLabelView extends SLabelView {
     }
 }
 
+@injectable()
 export class RelationshipLabelView extends SLabelView {
     render(label: Readonly<SLabel>, context: RenderingContext): VNode {
         const vnode = <text class-sprotty-label={true} class-relationship={true}>{label.text}</text>;


### PR DESCRIPTION
Changes include...
* Changes to the way OML elements are rendered in the diagram
* Views for previously unrendered OML elements
* Upgrade Sprotty to the latest version
* Upgrade Theia to its latest version.
* Basic view for the diagram editing menu
* New model for label editing through the diagram

With the latest version of Theia, **Node.js v10** is now required to run it.